### PR TITLE
hotfix: Handle no ticket leap event IDs to filter on

### DIFF
--- a/src/api/getClasses.ts
+++ b/src/api/getClasses.ts
@@ -55,6 +55,11 @@ export const EMPTY_CLASS: Readonly<Nullable<Class>> = {
 export async function getDetailsForClasses(
   ticketleapEventIds: Array<number>,
 ): Promise<Map<number, Class>> {
+  // contentful does not handle empty array filters and will throw a 400
+  if (ticketleapEventIds.length === 0) {
+    return Promise.resolve(new Map());
+  }
+
   const response = await contentfulClient.getEntries<ClassSkeleton>({
     content_type: "class",
     "fields.ticketleapEventId[in]": ticketleapEventIds,

--- a/src/api/getShows.ts
+++ b/src/api/getShows.ts
@@ -29,6 +29,11 @@ export const EMPTY_SHOW: Readonly<Nullable<Show>> = {
 export async function getDetailsForShows(
   ticketleapEventIds: Array<number>,
 ): Promise<Map<number, Show>> {
+  // contentful does not handle empty array filters and will throw a 400
+  if (ticketleapEventIds.length === 0) {
+    return Promise.resolve(new Map());
+  }
+
   const response = await contentfulClient.getEntries<ShowSkeleton>({
     content_type: "show",
     "fields.ticketleapEventId[in]": ticketleapEventIds,


### PR DESCRIPTION
Contentful apparently doesn't handle empty arrays as filters and will throw a 400 if you try. This handles that case now.