### PR TITLE
feat: Show next x events on homepage

### DIFF
--- a/src/api/getShowListings.ts
+++ b/src/api/getShowListings.ts
@@ -30,12 +30,21 @@ export type ShowListing = TicketLeapShowListing & Nullable<Show>;
 export async function getShowListings({
   from,
   to,
+  limit,
 }: {
   from: number;
-  to: number;
+  to?: number;
+  limit?: number;
 }): Promise<Array<ShowListing>> {
+  const upcomingShowsUrl = new URL(
+    "https://www.ticketleap.events/api/organization-listing/catch/range",
+  );
+  upcomingShowsUrl.searchParams.set("start", from.toString());
+  if (typeof to === "number") {
+    upcomingShowsUrl.searchParams.set("end", to.toString());
+  }
   const upcomingShows: Array<TicketLeapShowListing> = await fetch(
-    `https://www.ticketleap.events/api/organization-listing/catch/range?start=${from}&end=${to}`,
+    upcomingShowsUrl,
   )
     .then((res) => res.json())
     .then((data) =>
@@ -45,9 +54,9 @@ export async function getShowListings({
       })),
     );
 
-  const sortedUpcomingShows = [...upcomingShows].sort(
-    (a, b) => Date.parse(a.event_start) - Date.parse(b.event_start),
-  );
+  const sortedUpcomingShows = [...upcomingShows]
+    .sort((a, b) => Date.parse(a.event_start) - Date.parse(b.event_start))
+    .slice(0, limit);
 
   const showDetailsMap = await getDetailsForShows(
     sortedUpcomingShows.map((showListing) => showListing.listing_id),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getUnixTime, addMonths } from "date-fns";
+import { getUnixTime, addYears } from "date-fns";
 import { Icon } from "astro-icon/components";
 
 import { getShowListings } from "~/api/getShowListings";
@@ -11,13 +11,19 @@ import UpcomingClassCard from "~/components/UpcomingClassCard.astro";
 import NextShowCallout from "~/components/NextShowCallout.astro";
 import UpcomingShowCard from "~/components/UpcomingShowCard.astro";
 
+const today = new Date();
+const todayTsecs = getUnixTime(today);
+const nextYearTsecs = getUnixTime(addYears(today, 1));
+
 const upcomingShowsPromise = getShowListings({
-  from: getUnixTime(new Date()),
-  to: getUnixTime(addMonths(new Date(), 1)),
+  from: todayTsecs,
+  to: nextYearTsecs,
+  limit: 5,
 });
 const upcomingClassesPromise = getClassListings({
-  from: getUnixTime(new Date()),
-  to: getUnixTime(addMonths(new Date(), 1)),
+  from: todayTsecs,
+  to: nextYearTsecs,
+  limit: 4,
 });
 
 const [upcomingShows, upcomingClasses] = await Promise.all([


### PR DESCRIPTION
Previously we were just showing events for the next month. With this work, we'll look into the next year and pick the next 'x' events.

Limiting it to a year to avoid pulling in this class event:
https://www.ticketleap.events/tickets/catch-u/zz-accountcredit 