### PR TITLE
fix: Ticketleap API change - "status" field is now an actual word instead of numbers

### DIFF
--- a/src/api/utils/getTicketLeapListings.ts
+++ b/src/api/utils/getTicketLeapListings.ts
@@ -16,7 +16,7 @@ export interface TicketLeapEventsResponse {
         event_id: string;
         start: string; // date string
         end: string; // usually empty string
-        status: string; // numbers as strings. idk what each one means, but "5" seems to be "active"
+        status: string;
       }>;
     };
   }>;
@@ -63,9 +63,8 @@ export async function getTicketLeapListings(
         // TODO: double check this when Daylight Savings starts in March as this number could change.
         const listingStart = addHours(parseISO(listing.start), 5);
 
-        // "5" seems to be the "active" status for a listing
         return (
-          listing.status === "5" &&
+          listing.status === "active" &&
           // the parent event may have listings from the past, so filter out anything before "today" here
           now < listingStart
         );


### PR DESCRIPTION
We do a status check on each Ticketleap listing to make sure it is active and available for purchase. Previously, this "status" field was a number (in string form) where each number had a secret meaning. It looks like Ticketleap updated their API to use real words instead of numbers for this "status" field.

This work replaces the filter check to check for "active" instead of "5."

![image](https://github.com/user-attachments/assets/46ac6c1d-3b7f-4f57-88fd-fc603dbd8a61)