### PR TITLE
feat: Calendar controls and caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "astro-seo-metadata": "^0.6.0",
         "contentful": "^11.5.4",
         "date-fns": "^4.1.0",
+        "quick-lru": "^7.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sharp": "^0.33.5",
@@ -728,6 +729,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -7368,15 +7378,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -9332,6 +9333,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-lru": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
+      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/radix3": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "astro-seo-metadata": "^0.6.0",
     "contentful": "^11.5.4",
     "date-fns": "^4.1.0",
+    "quick-lru": "^7.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sharp": "^0.33.5",

--- a/src/api/getClassListings.ts
+++ b/src/api/getClassListings.ts
@@ -2,6 +2,7 @@ import { EMPTY_CLASS, getDetailsForClasses, type Class } from "./getClasses";
 import { getTicketLeapEventListings } from "./utils/getTicketLeapListing";
 import {
   getTicketLeapListings,
+  type GetTicketLeapListingsOptions,
   type TicketLeapListing,
 } from "./utils/getTicketLeapListings";
 import { getTicketLeapPrice } from "./utils/getTicketLeapPrice";
@@ -12,18 +13,17 @@ export interface TicketLeapClassListing extends TicketLeapListing {
 
 export type ClassListing = TicketLeapClassListing & Nullable<Class>;
 
-interface GetClassListingsOptions {
-  limit?: number;
+interface GetClassListingsOptions extends GetTicketLeapListingsOptions {
   eventId?: number;
 }
 
 export async function getClassListings({
-  limit,
   eventId,
+  ...options
 }: GetClassListingsOptions = {}): Promise<Array<ClassListing>> {
   const classListings = eventId
-    ? await getTicketLeapEventListings(eventId, "classes", limit)
-    : await getTicketLeapListings("classes", limit);
+    ? await getTicketLeapEventListings(eventId, "classes", options.limit)
+    : await getTicketLeapListings("classes", options);
   if (classListings === null) {
     return [];
   }

--- a/src/api/getShowListings.ts
+++ b/src/api/getShowListings.ts
@@ -1,5 +1,6 @@
 import { EMPTY_SHOW, getDetailsForShows, type Show } from "./getShows";
 import {
+  type GetTicketLeapListingsOptions,
   type TicketLeapListing,
   getTicketLeapListings,
 } from "./utils/getTicketLeapListings";
@@ -11,12 +12,10 @@ export interface TicketLeapShowListing extends TicketLeapListing {
 
 export type ShowListing = TicketLeapShowListing & Nullable<Show>;
 
-export async function getShowListings({
-  limit,
-}: {
-  limit?: number;
-} = {}): Promise<Array<ShowListing>> {
-  const showListings = await getTicketLeapListings("shows", limit);
+export async function getShowListings(
+  options: GetTicketLeapListingsOptions = {},
+): Promise<Array<ShowListing>> {
+  const showListings = await getTicketLeapListings("shows", options);
 
   const eventIds = Array.from(
     new Set(showListings.map((listing) => listing.eventId)),

--- a/src/api/utils/getTicketLeapListing.ts
+++ b/src/api/utils/getTicketLeapListing.ts
@@ -10,9 +10,9 @@ export interface TicketLeapEventResponse {
 }
 
 const localCache = new LRUCache<string, TicketLeapEventResponse>({
-  maxSize: 10,
-  // 10 minutes
-  maxAge: 1000 * 60 * 10,
+  maxSize: 25,
+  // 30 minutes
+  maxAge: 1000 * 60 * 30,
 });
 
 const fetchWithCache = async (

--- a/src/api/utils/getTicketLeapListings.ts
+++ b/src/api/utils/getTicketLeapListings.ts
@@ -43,8 +43,8 @@ export interface GetTicketLeapListingsOptions {
 
 const localCache = new LRUCache<string, TicketLeapEventsResponse>({
   maxSize: 10,
-  // 10 minutes
-  maxAge: 1000 * 60 * 10,
+  // 30 minutes
+  maxAge: 1000 * 60 * 30,
 });
 
 const fetchWithCache = async (

--- a/src/api/utils/getTicketLeapPrice.ts
+++ b/src/api/utils/getTicketLeapPrice.ts
@@ -1,12 +1,25 @@
+import LRUCache from "quick-lru";
+
 const priceFormatter = Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
+});
+
+const localCache = new LRUCache<number, string>({
+  maxSize: 30,
+  // 1 hour
+  maxAge: 1000 * 60 * 60,
 });
 
 export async function getTicketLeapPrice(
   type: "shows" | "classes",
   eventId: number,
 ): Promise<string> {
+  const cacheHit = localCache.get(eventId);
+  if (cacheHit) {
+    return Promise.resolve(cacheHit);
+  }
+
   return fetch(
     `https://admin.ticketleap.events/api/v1/events/${eventId}/relationships/price-levels`,
     {
@@ -19,8 +32,14 @@ export async function getTicketLeapPrice(
     },
   )
     .then((res) => res.json())
-    .then((res) =>
-      priceFormatter.format(res[0].data.attributes.price.amount / 100),
-    )
+    .then((res) => {
+      const eventPrice = priceFormatter.format(
+        res[0].data.attributes.price.amount / 100,
+      );
+
+      localCache.set(eventId, eventPrice);
+
+      return eventPrice;
+    })
     .catch(() => "");
 }

--- a/src/api/utils/getTicketLeapPrice.ts
+++ b/src/api/utils/getTicketLeapPrice.ts
@@ -6,9 +6,9 @@ const priceFormatter = Intl.NumberFormat("en-US", {
 });
 
 const localCache = new LRUCache<number, string>({
-  maxSize: 30,
+  maxSize: 50,
   // 1 hour
-  maxAge: 1000 * 60 * 60,
+  maxAge: 1000 * 60 * 60 * 1,
 });
 
 export async function getTicketLeapPrice(

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -18,7 +18,8 @@ const GTM_ID = "GTM-WQRTM3H3";
 
 Astro.response.headers.set(
   "Cache-Control",
-  "public, max-age=3600, must-revalidate",
+  // 10 minutes
+  "public, max-age=600, must-revalidate",
 );
 ---
 

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -18,8 +18,8 @@ const GTM_ID = "GTM-WQRTM3H3";
 
 Astro.response.headers.set(
   "Cache-Control",
-  // 10 minutes
-  "public, max-age=600, must-revalidate",
+  // 30 minutes
+  "public, max-age=0, s-maxage=1800, must-revalidate",
 );
 ---
 

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -15,6 +15,11 @@ type Props = {
 const { title, class: className } = Astro.props;
 
 const GTM_ID = "GTM-WQRTM3H3";
+
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=3600, must-revalidate",
+);
 ---
 
 <html lang="en">

--- a/src/pages/shows/index.astro
+++ b/src/pages/shows/index.astro
@@ -91,8 +91,13 @@ const nextMonthHref: URL = (() => {
         </a>
       )
     }
-    <h3 class="text-primary-purple text-4xl font-serif font-bold">
-      {format(fromDate, "MMMM")}
+    <h3
+      class="text-primary-purple text-4xl font-serif font-bold flex items-center gap-2"
+    >
+      <Icon name="calendar" class="inline" />
+      <span>
+        {format(fromDate, "MMMM")}
+      </span>
     </h3>
     <a
       name="from"

--- a/src/pages/shows/index.astro
+++ b/src/pages/shows/index.astro
@@ -1,5 +1,14 @@
 ---
 import { Icon } from "astro-icon/components";
+import {
+  addMonths,
+  parseISO,
+  format,
+  subMonths,
+  isSameMonth,
+  setDate,
+  isMatch,
+} from "date-fns";
 
 import { getShowListings } from "~/api/getShowListings";
 
@@ -7,18 +16,63 @@ import RootLayout from "~/layouts/RootLayout.astro";
 import ShowDateTime from "~/components/ShowDateTime.astro";
 import CoralButtonLink from "~/components/CoralButtonLink.astro";
 import LinkedImage from "~/components/LinkedImage.astro";
+import RemixIcon from "~/components/RemixIcon.astro";
+
+const fromDateParam = Astro.url.searchParams.get("from");
+
+if (fromDateParam && !isMatch(fromDateParam, "yyyy-MM-dd")) {
+  return Astro.redirect("/shows");
+}
+
+const now = new Date();
+let fromDate = fromDateParam ? parseISO(fromDateParam) : now;
+fromDate = fromDate < now ? now : fromDate;
+const toDate = setDate(addMonths(fromDate, 1), 1);
 
 const upcomingShows = await getShowListings({
-  limit: 15,
+  start: fromDate,
+  end: toDate,
 });
+
+const startOfFromDateMonth = setDate(fromDate, 1);
+let prevMonth = subMonths(startOfFromDateMonth, 1);
+prevMonth = prevMonth < now ? now : prevMonth;
+const nextMonth = addMonths(startOfFromDateMonth, 1);
 ---
 
 <RootLayout title="Upcoming Shows" class="lg:px-16">
   <h1
-    class="text-primary-purple text-6xl font-serif font-bold px-4 pt-8 pb-12 lg:pt-32 lg:border-b-2 border-light-purple bg-shapes"
+    class="text-primary-purple text-6xl font-serif font-bold px-4 pt-8 pb-12 lg:pt-32 bg-shapes"
   >
-    Calendar
+    <a href="/shows">Calendar</a>
   </h1>
+  <nav class="lg:border-b-2 border-light-purple pb-12 px-4">
+    <form method="get" action="/shows" class="flex items-center gap-2">
+      {
+        isSameMonth(fromDate, now) ? null : (
+          <button
+            name="from"
+            value={format(prevMonth, "yyyy-MM-dd")}
+            aria-label="View the previous month's shows"
+            class="hover:bg-purple-400/20 transition-colors rounded-md p-1"
+          >
+            <RemixIcon icon="arrow-left-s" variant="line" />
+          </button>
+        )
+      }
+      <h3 class="text-primary-purple text-4xl font-serif font-bold">
+        {format(fromDate, "MMMM")}
+      </h3>
+      <button
+        name="from"
+        value={format(nextMonth, "yyyy-MM-dd")}
+        aria-label="View next month's shows"
+        class="hover:bg-purple-400/20 transition-colors rounded-md p-1"
+      >
+        <RemixIcon icon="arrow-right-s" variant="line" />
+      </button>
+    </form>
+  </nav>
   <!-- desktop view -->
   <ul class="hidden flex-col lg:flex">
     {

--- a/src/pages/shows/index.astro
+++ b/src/pages/shows/index.astro
@@ -25,8 +25,16 @@ if (fromDateParam && !isMatch(fromDateParam, "yyyy-MM-dd")) {
 }
 
 const now = new Date();
-let fromDate = fromDateParam ? parseISO(fromDateParam) : now;
-fromDate = fromDate < now ? now : fromDate;
+
+const fromDate: Date = (() => {
+  const startDate = fromDateParam ? parseISO(fromDateParam) : null;
+  if (startDate && startDate >= now) {
+    return startDate;
+  } else {
+    return now;
+  }
+})();
+
 const toDate = setDate(addMonths(fromDate, 1), 1);
 
 const upcomingShows = await getShowListings({
@@ -35,9 +43,32 @@ const upcomingShows = await getShowListings({
 });
 
 const startOfFromDateMonth = setDate(fromDate, 1);
-let prevMonth = subMonths(startOfFromDateMonth, 1);
-prevMonth = prevMonth < now ? now : prevMonth;
+
+const prevMonth: Date | null = (() => {
+  const lastMonth = subMonths(startOfFromDateMonth, 1);
+  if (lastMonth < now) {
+    return null;
+  } else {
+    return lastMonth;
+  }
+})();
+
+const prevMonthHref: URL = (() => {
+  const destinationUrl = new URL(Astro.url);
+  if (prevMonth) {
+    destinationUrl.searchParams.set("from", format(prevMonth, "yyyy-MM-dd"));
+  } else {
+    destinationUrl.searchParams.delete("from");
+  }
+  return destinationUrl;
+})();
+
 const nextMonth = addMonths(startOfFromDateMonth, 1);
+const nextMonthHref: URL = (() => {
+  const destinationUrl = new URL(Astro.url);
+  destinationUrl.searchParams.set("from", format(nextMonth, "yyyy-MM-dd"));
+  return destinationUrl;
+})();
 ---
 
 <RootLayout title="Upcoming Shows" class="lg:px-16">
@@ -46,32 +77,31 @@ const nextMonth = addMonths(startOfFromDateMonth, 1);
   >
     <a href="/shows">Calendar</a>
   </h1>
-  <nav class="lg:border-b-2 border-light-purple pb-12 px-4">
-    <form method="get" action="/shows" class="flex items-center gap-2">
-      {
-        isSameMonth(fromDate, now) ? null : (
-          <button
-            name="from"
-            value={format(prevMonth, "yyyy-MM-dd")}
-            aria-label="View the previous month's shows"
-            class="hover:bg-purple-400/20 transition-colors rounded-md p-1"
-          >
-            <RemixIcon icon="arrow-left-s" variant="line" />
-          </button>
-        )
-      }
-      <h3 class="text-primary-purple text-4xl font-serif font-bold">
-        {format(fromDate, "MMMM")}
-      </h3>
-      <button
-        name="from"
-        value={format(nextMonth, "yyyy-MM-dd")}
-        aria-label="View next month's shows"
-        class="hover:bg-purple-400/20 transition-colors rounded-md p-1"
-      >
-        <RemixIcon icon="arrow-right-s" variant="line" />
-      </button>
-    </form>
+  <nav
+    class="lg:border-b-2 border-light-purple pb-12 px-4 flex items-center gap-2"
+  >
+    {
+      isSameMonth(fromDate, now) ? null : (
+        <a
+          href={prevMonthHref}
+          aria-label="View the previous month's shows"
+          class="hover:bg-purple-400/20 transition-colors rounded-md p-1"
+        >
+          <RemixIcon icon="arrow-left-s" variant="line" />
+        </a>
+      )
+    }
+    <h3 class="text-primary-purple text-4xl font-serif font-bold">
+      {format(fromDate, "MMMM")}
+    </h3>
+    <a
+      name="from"
+      href={nextMonthHref}
+      aria-label="View next month's shows"
+      class="hover:bg-purple-400/20 transition-colors rounded-md p-1"
+    >
+      <RemixIcon icon="arrow-right-s" variant="line" />
+    </a>
   </nav>
   <!-- desktop view -->
   <ul class="hidden flex-col lg:flex">


### PR DESCRIPTION
Added 30 minute caching to TicketLeap and page responses. TicketLeap price levels are cached at 1 hour. Caching page responses based on [Vercel recommendations](https://vercel.com/docs/headers/cache-control-headers#recommended-settings).

New controls to the shows calendar page:

<img width="2830" height="1634" alt="image" src="https://github.com/user-attachments/assets/e9b1157b-ce77-4e4b-9adb-a9a8a0f38e28" />

<img width="2829" height="1458" alt="image" src="https://github.com/user-attachments/assets/e862f7a3-6a8d-4233-a633-00b3e6f3a910" />
