### PR TITLE
feat: add inline "See all" CTAs to homepage card scroll on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,29 +65,14 @@ const [nextShow, ...otherShows] = upcomingShows.slice(0, 5);
   }
 
   a.see_all_link {
-    @apply underline font-serif font-bold flex gap-2 items-center m-4 w-fit ml-auto xl:pr-16;
+    @apply underline font-serif font-bold gap-2 items-center m-4 w-fit ml-auto xl:pr-16;
   }
 
   li.inline-cta {
-    @apply flex items-center justify-center min-w-[200px] flex-shrink-0;
+    @apply items-center justify-center min-w-[200px] flex-shrink-0;
 
     a {
       @apply font-serif font-bold text-lg flex gap-2 items-center underline;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    li.inline-cta {
-      display: none;
-    }
-    a.see_all_link {
-      display: flex;
-    }
-  }
-
-  @media (max-width: 1023px) {
-    a.see_all_link {
-      display: none;
     }
   }
 
@@ -114,13 +99,13 @@ const [nextShow, ...otherShows] = upcomingShows.slice(0, 5);
           </li>
         ))
       }
-      <li class="inline-cta">
+      <li class="inline-cta flex lg:hidden">
         <a href="/shows" class="text-peach">
           See all shows <ArrowRightIcon name="arrow-right" class="size-5" />
         </a>
       </li>
     </ul>
-    <a href="/shows" class="see_all_link text-peach">
+    <a href="/shows" class="see_all_link text-peach hidden lg:flex">
       See all shows <ArrowRightIcon name="arrow-right" class="size-5" />
     </a>
   </section>
@@ -137,13 +122,13 @@ const [nextShow, ...otherShows] = upcomingShows.slice(0, 5);
           </li>
         ))
       }
-      <li class="inline-cta">
+      <li class="inline-cta flex lg:hidden">
         <a href="/classes" class="text-primary-purple">
           See all classes <ArrowRightIcon name="arrow-right" class="size-5" />
         </a>
       </li>
     </ul>
-    <a href="/classes" class="see_all_link text-primary-purple">
+    <a href="/classes" class="see_all_link text-primary-purple hidden lg:flex">
       See all classes <ArrowRightIcon name="arrow-right" class="size-5" />
     </a>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,6 +68,29 @@ const [nextShow, ...otherShows] = upcomingShows.slice(0, 5);
     @apply underline font-serif font-bold flex gap-2 items-center m-4 w-fit ml-auto xl:pr-16;
   }
 
+  li.inline-cta {
+    @apply flex items-center justify-center min-w-[200px] flex-shrink-0;
+
+    a {
+      @apply font-serif font-bold text-lg flex gap-2 items-center underline;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    li.inline-cta {
+      display: none;
+    }
+    a.see_all_link {
+      display: flex;
+    }
+  }
+
+  @media (max-width: 1023px) {
+    a.see_all_link {
+      display: none;
+    }
+  }
+
   ul.card_list {
     @apply flex overflow-x-auto gap-4 pt-2 pb-4 px-4 xl:px-16;
   }
@@ -91,6 +114,11 @@ const [nextShow, ...otherShows] = upcomingShows.slice(0, 5);
           </li>
         ))
       }
+      <li class="inline-cta">
+        <a href="/shows" class="text-peach">
+          See all shows <ArrowRightIcon name="arrow-right" class="size-5" />
+        </a>
+      </li>
     </ul>
     <a href="/shows" class="see_all_link text-peach">
       See all shows <ArrowRightIcon name="arrow-right" class="size-5" />
@@ -109,6 +137,11 @@ const [nextShow, ...otherShows] = upcomingShows.slice(0, 5);
           </li>
         ))
       }
+      <li class="inline-cta">
+        <a href="/classes" class="text-primary-purple">
+          See all classes <ArrowRightIcon name="arrow-right" class="size-5" />
+        </a>
+      </li>
     </ul>
     <a href="/classes" class="see_all_link text-primary-purple">
       See all classes <ArrowRightIcon name="arrow-right" class="size-5" />


### PR DESCRIPTION
On viewports below 1024px, the "See all shows" and "See all classes" links now appear as the last item in the horizontal card scroll, giving users a call to action while browsing. The standalone links below the cards are hidden on mobile and shown on desktop (lg+).