### PR TITLE
feat: update classes card text with bold class names

### DIFF
--- a/src/pages/classes/index.astro
+++ b/src/pages/classes/index.astro
@@ -68,7 +68,7 @@ import OtherClassesImg from "~/images/class-pathways/other-classes.png";
         href="/classes/unlocking-the-self"
       >
         <Fragment slot="description">
-          Growing my personal skills and meeting people through improv through <span class="font-semibold">Unlocking the Self</span>
+          Growing my personal skills and meeting people through improv with <span class="font-semibold">Unlocking the Self</span>
         </Fragment>
       </PathwayCard>
     </li>

--- a/src/pages/classes/index.astro
+++ b/src/pages/classes/index.astro
@@ -68,7 +68,7 @@ import OtherClassesImg from "~/images/class-pathways/other-classes.png";
         href="/classes/unlocking-the-self"
       >
         <Fragment slot="description">
-          Growing my personal skills and meeting people through improv
+          Growing my personal skills and meeting people through improv through <span class="font-semibold">Unlocking the Self</span>
         </Fragment>
       </PathwayCard>
     </li>
@@ -80,8 +80,7 @@ import OtherClassesImg from "~/images/class-pathways/other-classes.png";
         href="/classes/performance-track"
       >
         <Fragment slot="description">
-          Get stage ready and learn how to perform improv comedy with our&nbsp;
-          <span class="font-semibold">Performance Track</span>
+          Get stage ready and learn how to perform improv comedy with our <span class="font-semibold">Performance Track</span>
         </Fragment>
       </PathwayCard>
     </li>
@@ -93,7 +92,7 @@ import OtherClassesImg from "~/images/class-pathways/other-classes.png";
         href="/classes/standup"
       >
         <Fragment slot="description">
-          Learning how to create and deliver stand-up comedy
+          Learning how to create and deliver <span class="font-semibold">stand-up comedy</span>
         </Fragment>
       </PathwayCard>
     </li>


### PR DESCRIPTION
Add "through Unlocking the Self" to the first card description and bold the class names (Unlocking the Self, Performance Track, stand-up comedy). Also fix extra whitespace before bolded text on all cards.