### PR TITLE
fix: Update TicketLeap path

### DIFF
--- a/check_ids.ts
+++ b/check_ids.ts
@@ -2,7 +2,7 @@
 import type { TicketLeapEventsResponse } from "~/api/utils/getTicketLeapListings";
 
 const upcomingClasses = await fetch(
-  "https://admin.ticketleap.events/api/v1/events?filter=upcoming=true",
+  "https://admin.ticketleap.com/api/v1/events?filter=upcoming=true",
   {
     headers: {
       "X-API-Token": Deno.env.get("TICKETLEAP_CLASSES_TOKEN")!,
@@ -19,7 +19,7 @@ const upcomingClasses = await fetch(
   });
 
 const upcomingShows = await fetch(
-  "https://admin.ticketleap.events/api/v1/events?filter=upcoming=true",
+  "https://admin.ticketleap.com/api/v1/events?filter=upcoming=true",
   {
     headers: {
       "X-API-Token": Deno.env.get("TICKETLEAP_SHOWS_TOKEN")!,

--- a/src/api/utils/getTicketLeapListing.ts
+++ b/src/api/utils/getTicketLeapListing.ts
@@ -27,7 +27,7 @@ const fetchWithCache = async (
 
   const res = await fetch(
     // https://technically.showclix.com/events.html
-    `https://admin.ticketleap.events/api/v1/events/${eventId}?filter=upcoming=true`,
+    `https://admin.ticketleap.com/api/v1/events/${eventId}?filter=upcoming=true`,
     {
       headers: {
         "X-API-Token":
@@ -90,7 +90,7 @@ export async function getTicketLeapEventListings(
         ? `https:${event.attributes.image}`
         : "/images/CATCh-Placeholder.jpg",
       date: toDate(listing.start, { timeZone: "America/New_York" }),
-      listingUrl: `https://www.ticketleap.events/tickets/${
+      listingUrl: `https://events.ticketleap.com/tickets/${
         event.attributes.slug
       }?date=${Date.parse(listing.start) / 1000}`,
     }));

--- a/src/api/utils/getTicketLeapListings.ts
+++ b/src/api/utils/getTicketLeapListings.ts
@@ -58,7 +58,7 @@ const fetchWithCache = async (
 
   const res = await fetch(
     // https://technically.showclix.com/events.html
-    "https://admin.ticketleap.events/api/v1/events?filter=upcoming=true",
+    "https://admin.ticketleap.com/api/v1/events?filter=upcoming=true",
     {
       headers: {
         "X-API-Token":
@@ -120,7 +120,7 @@ export async function getTicketLeapListings(
           name: event.name,
           image: imageUrl,
           date: toDate(listing.start, { timeZone: "America/New_York" }),
-          listingUrl: `https://www.ticketleap.events/tickets/${
+          listingUrl: `https://events.ticketleap.com/tickets/${
             event.slug
           }?date=${Date.parse(listing.start) / 1000}`,
         };

--- a/src/api/utils/getTicketLeapPrice.ts
+++ b/src/api/utils/getTicketLeapPrice.ts
@@ -21,7 +21,7 @@ export async function getTicketLeapPrice(
   }
 
   return fetch(
-    `https://admin.ticketleap.events/api/v1/events/${eventId}/relationships/price-levels`,
+    `https://admin.ticketleap.com/api/v1/events/${eventId}/relationships/price-levels`,
     {
       headers: {
         "X-API-Token":

--- a/src/pages/internal/check-ids.astro
+++ b/src/pages/internal/check-ids.astro
@@ -3,7 +3,7 @@ import type { TicketLeapEventsResponse } from "~/api/utils/getTicketLeapListings
 import InternalLayout from "~/layouts/InternalLayout.astro";
 
 const showsP = fetch(
-  "https://admin.ticketleap.events/api/v1/events?filter=upcoming=true",
+  "https://admin.ticketleap.com/api/v1/events?filter=upcoming=true",
   {
     headers: {
       "X-API-Token": import.meta.env.TICKETLEAP_SHOWS_TOKEN,
@@ -22,7 +22,7 @@ const showsP = fetch(
   });
 
 const classesP = await fetch(
-  "https://admin.ticketleap.events/api/v1/events?filter=upcoming=true",
+  "https://admin.ticketleap.com/api/v1/events?filter=upcoming=true",
   {
     headers: {
       "X-API-Token": import.meta.env.TICKETLEAP_CLASSES_TOKEN,


### PR DESCRIPTION
TicketLeap updated their paths from `ticketleap.events` to `ticketleap.com`. This PR updates our references to match that.