### PR TITLE
fix: Stand up class not showing on stand up page

### DIFF
--- a/src/pages/classes/class-ids.ts
+++ b/src/pages/classes/class-ids.ts
@@ -3,5 +3,5 @@ export const ClassIDs = {
   PT1: 853,
   PT2: 1222,
   PT3: 14769,
-  Standup: 1629007,
+  Standup: 2129576,
 } as const;


### PR DESCRIPTION
Quick and dirty fix for now. Needs a more robust solution in the future.

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/f7329133-8f65-4bc9-a78f-c38b2e0b0129" />
