### PR TITLE
Stories of Awesomeness: testimonial carousel + dedicated Stories page

### DIFF
--- a/src/components/Header/routes.ts
+++ b/src/components/Header/routes.ts
@@ -34,6 +34,10 @@ export const routes: Record<string, Array<Route>> = {
       path: "/classes",
     },
     {
+      label: "Stories of Awesomeness",
+      path: "/classes/stories",
+    },
+    {
       label: "Policies",
       path: "/policies/class-policies",
     },

--- a/src/pages/classes/_data/stories.ts
+++ b/src/pages/classes/_data/stories.ts
@@ -2,7 +2,12 @@ export type Story = {
   name: string;
   topic: string;
   videoId: string;
+  /** Short teaser quote shown in the carousel on the class page. */
   quote: string;
+  /** Full quote shown on the dedicated stories page. */
+  fullQuote: string;
+  /** Long-form description paragraphs shown on the dedicated stories page. */
+  paragraphs: string[];
 };
 
 export const stories: Story[] = [
@@ -11,6 +16,12 @@ export const stories: Story[] = [
     topic: "Confidence",
     videoId: "JivQSqJrKIw",
     quote: "That first moment is scary, but then it always turns out fun.",
+    fullQuote: `“That first moment is scary, but then it always turns out fun. That's one of the things you really learn: whatever you say, that's what the scene is. It really helps you with yourself, with how your mind works, and interacting with other people.”`,
+    paragraphs: [
+      `"I want to feel more confident" is a goal we hear frequently on Day 1 of Improv Fundamentals class. Your beginning improv class is a safe, supportive, energizing, and hilarious space to find your confidence.`,
+      `In each 2.5 hour class, students will learn the foundations of improv such as; saying “yes, and…,” active listening, staying present in the moment, collaboration, and empowering the self. In this class, there are no mistakes and everything is a gift as we reinvigorate our sense of play!`,
+      `Join the fun today! In addition to 6 weeks of class, your tuition also gives you FREE tickets to come see our shows. That's right, FREE shows for you to any of our non-sold-out performances while you're a student.`,
+    ],
   },
   {
     name: "Hillary",
@@ -18,5 +29,9 @@ export const stories: Story[] = [
     videoId: "hDXuUbfYwSU",
     quote:
       'It’s about saying “yes” to yourself, to shedding your fears and leaving them at the door.',
+    fullQuote: `“It's about saying "yes" to yourself, to shedding your fears and leaving them at the door.”`,
+    paragraphs: [
+      `How often do you find yourself saying "no," or "maybe" instead of saying "Yes"? In today's world, it can be easy to get caught up in social media, the news, and our daily grind. It's important to carve out time to say yes to ourselves and do something that challenges us. The classes at CATCh are all about creating an encouraging environment to students looking to develop the "self," as they express their creativity in a new way.`,
+    ],
   },
 ];

--- a/src/pages/classes/_data/stories.ts
+++ b/src/pages/classes/_data/stories.ts
@@ -1,0 +1,22 @@
+export type Story = {
+  name: string;
+  topic: string;
+  videoId: string;
+  quote: string;
+};
+
+export const stories: Story[] = [
+  {
+    name: "Clarissa",
+    topic: "Confidence",
+    videoId: "JivQSqJrKIw",
+    quote: "That first moment is scary, but then it always turns out fun.",
+  },
+  {
+    name: "Hillary",
+    topic: "Saying Yes",
+    videoId: "hDXuUbfYwSU",
+    quote:
+      'It’s about saying “yes” to yourself, to shedding your fears and leaving them at the door.',
+  },
+];

--- a/src/pages/classes/_styles/stories.module.css
+++ b/src/pages/classes/_styles/stories.module.css
@@ -1,0 +1,92 @@
+/* Page layout — matched to the parent class page
+   (unlocking-the-self.module.css .layout) so the "Stories of Awesomeness"
+   carousel and this "see all" destination read as one continuous page:
+   centered, max-width-capped column with a consistent vertical rhythm and a
+   desktop gutter that the breadcrumb/h1/section's `px-6 lg:px-0` utilities
+   rely on. Keep in sync with unlocking-the-self until a shared layout
+   component is extracted. */
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  max-width: 1264px;
+}
+
+@media (width >=1024px) {
+  .layout {
+    padding: 0px 1rem;
+    margin: auto;
+  }
+}
+
+/* Video story section: two alternating video/text blocks.
+   Stacked on mobile (the `flex-col` utility in the markup overrides the row
+   direction); a 2-up grid at lg+. Vertical gutter between the two blocks lives
+   here; the page-level horizontal gutter is supplied by the section's
+   `px-6 lg:px-0` utilities + the .layout `<main>` padding, NOT by this section
+   (so gutters match the breadcrumb/h1/testimonials and don't double-pad). */
+.awesomeness {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.two_col {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+}
+
+@media (width >=1024px) {
+  .two_col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4rem;
+    align-items: start;
+  }
+}
+
+.awesomeness_text_container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.awesomeness_text_container > h3 {
+  font-family: var(--font-serif);
+  font-size: var(--font-md);
+  font-weight: bold;
+  color: var(--primary-purple);
+}
+
+.awesomeness_text_container > blockquote {
+  font-style: italic;
+}
+
+/* Sub-label so the text testimonials read as a distinct group below the
+   video stories. Matches the site's serif/purple heading treatment rather
+   than introducing a new separator style. */
+.testimonials_heading {
+  font-family: var(--font-serif);
+  font-size: var(--font-lg);
+  font-weight: bold;
+  color: var(--primary-purple);
+  margin-bottom: 1.5rem;
+}
+
+/* Horizontally scrollable row of headshot testimonials. Scrolls on narrow
+   viewports; spaced out on desktop. The markup adds tabindex="0" + aria-label
+   so keyboard users can scroll the region (a bare overflow scroller has no
+   focusable stop); the focus-visible rule below makes that stop visible. */
+.testimonials {
+  display: flex;
+  justify-content: space-around;
+  padding: 1.5rem;
+  gap: 2.5rem;
+  overflow-x: auto;
+}
+
+.testimonials:focus-visible {
+  outline: 2px solid var(--primary-purple);
+  outline-offset: 2px;
+}

--- a/src/pages/classes/_styles/unlocking-the-self.module.css
+++ b/src/pages/classes/_styles/unlocking-the-self.module.css
@@ -27,39 +27,47 @@
   }
 }
 
-section.awesomeness {
+.stories {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  padding: 0px 1.75rem;
+  gap: 1rem;
+}
+
+.story_card {
+  /* Fixed width on mobile so the next card peeks (scroll affordance). */
+  flex: 0 0 auto;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 @media (width >=1024px) {
-  section.awesomeness {
-    padding: 0;
+  /* On desktop, grow to fill the row so a small set (2 cards) reads as a
+     deliberate, full layout rather than a sparse one. min-width keeps cards
+     legible as the set grows (they shrink to 280px, then the row scrolls);
+     max-width stops a single card from spanning the whole row. */
+  .story_card {
+    flex: 1 1 0;
+    min-width: 280px;
+    max-width: 520px;
   }
 }
 
-.awesomeness_text_container {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-
-  >h3 {
-    font-family: var(--font-serif);
-    font-size: var(--font-md);
-    font-weight: bold;
-  }
-
-  >blockquote {
-    font-style: italic;
-  }
+.story_name {
+  font-family: var(--font-serif);
+  font-weight: bold;
 }
 
-.testimonials {
-  display: flex;
-  justify-content: space-around;
-  padding: 1.5rem;
-  gap: 2.5rem;
-  overflow-x: auto;
+.story_quote {
+  font-style: italic;
+  line-height: 1.4;
+  text-wrap: pretty;
+  /* Keep card heights even and the section compact regardless of quote
+     length; full quote lives on the stories page. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
 }

--- a/src/pages/classes/stories.astro
+++ b/src/pages/classes/stories.astro
@@ -2,6 +2,7 @@
 import RootLayout from "~/layouts/RootLayout.astro";
 import YoutubeVideoEmbed from "~/components/YoutubeVideoEmbed.astro";
 import ClassBreadcrumbs from "./_components/ClassBreadcrumbs.astro";
+import { stories } from "./_data/stories";
 import Testimonial from "./_components/Testimonial.astro";
 import KristinHeadshot from "./_images/testimonial-headshots/Kristin.png";
 import KellyHeadshot from "./_images/testimonial-headshots/Kelly.png";
@@ -21,61 +22,35 @@ import styles from "./_styles/stories.module.css";
   </h1>
 
   <section class={`${styles.awesomeness} px-6 lg:px-0`}>
-    <div class={`${styles.two_col} flex-col`}>
-      <YoutubeVideoEmbed
-        title="Clarissa's Story — CATCh Improv Classes"
-        videoId="JivQSqJrKIw"
-      />
-      <div class={styles.awesomeness_text_container}>
-        <h3>Clarissa: Confidence</h3>
-        <blockquote>
-          “That first moment is scary, but then it always turns out fun. That's
-          one of the things you really learn: whatever you say, that's what the
-          scene is. It really helps you with yourself, with how your mind works,
-          and interacting with other people.”
-        </blockquote>
-        <p>
-          "I want to feel more confident" is a goal we hear frequently on Day 1
-          of Improv Fundamentals class. Your beginning improv class is a safe,
-          supportive, energizing, and hilarious space to find your confidence.
-        </p>
-        <p>
-          In each 2.5 hour class, students will learn the foundations of improv
-          such as; saying “yes, and…,” active listening, staying present in the
-          moment, collaboration, and empowering the self. In this class, there
-          are no mistakes and everything is a gift as we reinvigorate our sense
-          of play!
-        </p>
-        <p>
-          Join the fun today! In addition to 6 weeks of class, your tuition also
-          gives you FREE tickets to come see our shows. That's right, FREE shows
-          for you to any of our non-sold-out performances while you're a
-          student.
-        </p>
-      </div>
-    </div>
-    <div class={`${styles.two_col} flex-col`}>
-      <div class={styles.awesomeness_text_container}>
-        <h3>Hillary: Saying Yes</h3>
-        <blockquote>
-          “It's about saying "yes" to yourself, to shedding your fears and
-          leaving them at the door.”
-        </blockquote>
-        <p>
-          How often do you find yourself saying "no," or "maybe" instead of
-          saying "Yes"? In today's world, it can be easy to get caught up in
-          social media, the news, and our daily grind. It's important to carve
-          out time to say yes to ourselves and do something that challenges us.
-          The classes at CATCh are all about creating an encouraging environment
-          to students looking to develop the "self," as they express their
-          creativity in a new way.
-        </p>
-      </div>
-      <YoutubeVideoEmbed
-        title="Hillary's Story - CATCh Improv Class"
-        videoId="hDXuUbfYwSU"
-      />
-    </div>
+    {
+      stories.map((story, index) => {
+        const video = (
+          <YoutubeVideoEmbed
+            title={`${story.name}'s Story — CATCh Improv Classes`}
+            videoId={story.videoId}
+          />
+        );
+        const text = (
+          <div class={styles.awesomeness_text_container}>
+            <h3>
+              {story.name}: {story.topic}
+            </h3>
+            <blockquote>{story.fullQuote}</blockquote>
+            {story.paragraphs.map((paragraph) => (
+              <p>{paragraph}</p>
+            ))}
+          </div>
+        );
+
+        // Alternate which side the video sits on for visual rhythm.
+        return (
+          <div class={`${styles.two_col} flex-col`}>
+            {index % 2 === 0 ? video : text}
+            {index % 2 === 0 ? text : video}
+          </div>
+        );
+      })
+    }
   </section>
 
   <section class="px-6 lg:px-0">

--- a/src/pages/classes/stories.astro
+++ b/src/pages/classes/stories.astro
@@ -1,0 +1,115 @@
+---
+import RootLayout from "~/layouts/RootLayout.astro";
+import YoutubeVideoEmbed from "~/components/YoutubeVideoEmbed.astro";
+import ClassBreadcrumbs from "./_components/ClassBreadcrumbs.astro";
+import Testimonial from "./_components/Testimonial.astro";
+import KristinHeadshot from "./_images/testimonial-headshots/Kristin.png";
+import KellyHeadshot from "./_images/testimonial-headshots/Kelly.png";
+import JessHeadshot from "./_images/testimonial-headshots/Jess.png";
+import styles from "./_styles/stories.module.css";
+---
+
+<RootLayout title="Stories of Awesomeness - Classes" class={styles.layout}>
+  <div class="px-6 lg:px-0">
+    <ClassBreadcrumbs>Stories of Awesomeness</ClassBreadcrumbs>
+  </div>
+
+  <h1
+    class="text-primary-purple text-6xl font-serif font-bold bg-shapes pt-12 px-6 lg:px-0"
+  >
+    Stories of Awesomeness
+  </h1>
+
+  <section class={`${styles.awesomeness} px-6 lg:px-0`}>
+    <div class={`${styles.two_col} flex-col`}>
+      <YoutubeVideoEmbed
+        title="Clarissa's Story — CATCh Improv Classes"
+        videoId="JivQSqJrKIw"
+      />
+      <div class={styles.awesomeness_text_container}>
+        <h3>Clarissa: Confidence</h3>
+        <blockquote>
+          “That first moment is scary, but then it always turns out fun. That's
+          one of the things you really learn: whatever you say, that's what the
+          scene is. It really helps you with yourself, with how your mind works,
+          and interacting with other people.”
+        </blockquote>
+        <p>
+          "I want to feel more confident" is a goal we hear frequently on Day 1
+          of Improv Fundamentals class. Your beginning improv class is a safe,
+          supportive, energizing, and hilarious space to find your confidence.
+        </p>
+        <p>
+          In each 2.5 hour class, students will learn the foundations of improv
+          such as; saying “yes, and…,” active listening, staying present in the
+          moment, collaboration, and empowering the self. In this class, there
+          are no mistakes and everything is a gift as we reinvigorate our sense
+          of play!
+        </p>
+        <p>
+          Join the fun today! In addition to 6 weeks of class, your tuition also
+          gives you FREE tickets to come see our shows. That's right, FREE shows
+          for you to any of our non-sold-out performances while you're a
+          student.
+        </p>
+      </div>
+    </div>
+    <div class={`${styles.two_col} flex-col`}>
+      <div class={styles.awesomeness_text_container}>
+        <h3>Hillary: Saying Yes</h3>
+        <blockquote>
+          “It's about saying "yes" to yourself, to shedding your fears and
+          leaving them at the door.”
+        </blockquote>
+        <p>
+          How often do you find yourself saying "no," or "maybe" instead of
+          saying "Yes"? In today's world, it can be easy to get caught up in
+          social media, the news, and our daily grind. It's important to carve
+          out time to say yes to ourselves and do something that challenges us.
+          The classes at CATCh are all about creating an encouraging environment
+          to students looking to develop the "self," as they express their
+          creativity in a new way.
+        </p>
+      </div>
+      <YoutubeVideoEmbed
+        title="Hillary's Story - CATCh Improv Class"
+        videoId="hDXuUbfYwSU"
+      />
+    </div>
+  </section>
+
+  <section class="px-6 lg:px-0">
+    <h2 class={styles.testimonials_heading}>What students are saying</h2>
+    <ul
+      class={styles.testimonials}
+      tabindex="0"
+      aria-label="Student testimonials, scroll horizontally to read more"
+    >
+      <li>
+        <Testimonial name="Kristin" image={KristinHeadshot}>
+          “From Day 1, the class taught me not to be fearful and speak up; I felt
+          comfortable being my authentic self.”
+        </Testimonial>
+      </li>
+      <li>
+        <Testimonial name="Kelly" image={KellyHeadshot}>
+          <p>
+            “I'm 4 weeks into my improv class and I am loving it. I have always
+            enjoyed watching improv shows, and would always say 'I could never
+            do that.'
+          </p>
+          <p>Well, here I am, doing it. And it's fun and freeing and motivating.”</p>
+        </Testimonial>
+      </li>
+      <li>
+        <Testimonial name="Jess" image={JessHeadshot}>
+          “Of course I learned a lot about improv and how to work with a scene
+          partner. What I didn't realize was that I would walk away after 6
+          weeks having learned more about myself: how to be open and present to
+          what's in front of you, and to take life, and myself, a little less
+          seriously.”
+        </Testimonial>
+      </li>
+    </ul>
+  </section>
+</RootLayout>

--- a/src/pages/classes/unlocking-the-self.astro
+++ b/src/pages/classes/unlocking-the-self.astro
@@ -8,18 +8,61 @@ import { ClassIDs } from "./class-ids";
 import UtSHero from "./_images/UtSHero.png";
 import UpcomingClassItem from "./_components/UpcomingClassItem.astro";
 import YoutubeVideoEmbed from "~/components/YoutubeVideoEmbed.astro";
-import Testimonial from "./_components/Testimonial.astro";
-
-import KristinHeadshot from "./_images/testimonial-headshots/Kristin.png";
-import KellyHeadshot from "./_images/testimonial-headshots/Kelly.png";
-import JessHeadshot from "./_images/testimonial-headshots/Jess.png";
+import ArrowRightIcon from "~/icons/arrow-right.svg";
 import styles from "./_styles/unlocking-the-self.module.css";
 import ClassBreadcrumbs from "./_components/ClassBreadcrumbs.astro";
+import { stories } from "./_data/stories";
 
 const utsClasses = await getClassListings({
   eventId: ClassIDs.UnlockingTheSelf,
+}).catch((err) => {
+  // don't let a class-listing API failure crash the whole page
+  console.error("getClassListings failed for UnlockingTheSelf", err);
+  return [];
 });
 ---
+
+<style>
+  /* Carousel pattern matched to the homepage (src/pages/index.astro) so the
+     three card carousels — Upcoming shows, Upcoming classes, and these stories
+     — read as one component family. Keep these values in sync with index.astro
+     until the shared-component refactor lands. */
+  ul.card_list {
+    @apply flex overflow-x-auto gap-4 pt-2 pb-4 px-4 xl:px-16;
+  }
+
+  a.see_all_link {
+    @apply underline font-serif font-bold gap-2 items-center m-4 w-fit ml-auto xl:pr-16;
+  }
+
+  li.inline-cta {
+    @apply items-center justify-center min-w-[200px] flex-shrink-0;
+
+    a {
+      @apply font-serif font-bold text-lg flex gap-2 items-center underline;
+    }
+  }
+
+  /* Page-specific a11y affordances (not on the homepage): the scroller is a
+     focusable region, so it needs a visible focus ring; the see-all link too. */
+  ul.card_list:focus-visible {
+    @apply rounded-lg;
+    outline: 2px solid var(--primary-purple);
+    outline-offset: 2px;
+  }
+
+  a.see_all_link:focus-visible {
+    @apply rounded;
+    outline: 2px solid var(--primary-purple);
+    outline-offset: 3px;
+  }
+
+  li.inline-cta a:focus-visible {
+    @apply rounded;
+    outline: 2px solid var(--primary-purple);
+    outline-offset: 3px;
+  }
+</style>
 
 <RootLayout title="Unlocking the Self - Classes" class={styles.layout}>
   <div class="px-6 lg:px-0">
@@ -60,6 +103,42 @@ const utsClasses = await getClassListings({
       class=""
     />
   </section>
+  <section class={styles.stories} aria-labelledby="stories-heading">
+    <h2
+      id="stories-heading"
+      class="font-serif text-primary-purple text-xl px-6 lg:px-0"
+    >
+      Stories of Awesomeness
+    </h2>
+    <ul
+      class="card_list"
+      tabindex="0"
+      aria-label="Student stories, scroll to see more"
+    >
+      {
+        stories.map((story) => (
+          <li class={styles.story_card}>
+            <YoutubeVideoEmbed
+              title={`${story.name}'s Story — CATCh Improv Classes`}
+              videoId={story.videoId}
+            />
+            <h3 class={styles.story_name}>
+              {story.name}: {story.topic}
+            </h3>
+            <blockquote class={styles.story_quote}>{story.quote}</blockquote>
+          </li>
+        ))
+      }
+      <li class="inline-cta flex lg:hidden">
+        <a href="/classes/stories" class="text-primary-purple">
+          See all stories <ArrowRightIcon name="arrow-right" class="size-5" />
+        </a>
+      </li>
+    </ul>
+    <a href="/classes/stories" class="see_all_link text-primary-purple hidden lg:flex">
+      See all stories <ArrowRightIcon name="arrow-right" class="size-5" />
+    </a>
+  </section>
   <section>
     <h2 class="font-serif text-primary-purple text-xl px-6 lg:px-0">
       Upcoming Classes
@@ -77,95 +156,6 @@ const utsClasses = await getClassListings({
           </li>
         ))
       }
-    </ul>
-  </section>
-  <section class={styles.awesomeness}>
-    <h2 class="font-serif font-bold text-2xl">Stories of Awesomeness</h2>
-    <div class={`${styles.two_col} flex-col`}>
-      <YoutubeVideoEmbed
-        title="Clarissa's Story — CATCh Improv Classes"
-        videoId="JivQSqJrKIw"
-      />
-      <div class={styles.awesomeness_text_container}>
-        <h3>Clarissa: Confidence</h3>
-        <blockquote>
-          “That first moment is scary, but then it always turns out fun. That's
-          one of the things you really learn: whatever you say, that's what the
-          scene is. It really helps you with yourself, with how your mind works,
-          and interacting with other people.”
-        </blockquote>
-        <p>
-          "I want to feel more confident" is a goal we hear frequently on Day 1
-          of Improv Fundamentals class. Your beginning improv class is a safe,
-          supportive, energizing, and hilarious space to find your confidence.
-        </p>
-        <p>
-          In each 2.5 hour class, students will learn the foundations of improv
-          such as; saying “yes, and…,” active listening, staying present in the
-          moment, collaboration, and empowering the self. In this class, there
-          are no mistakes and everything is a gift as we reinvigorate our sense
-          of play!
-        </p>
-        <p>
-          Join the fun today! In addition to 6 weeks of class, your tuition also
-          gives you FREE tickets to come see our shows. That's right, FREE shows
-          for you to any of our non-sold-out performances while you're a
-          student.
-        </p>
-      </div>
-    </div>
-    <div class={`${styles.two_col} flex-col`}>
-      <div class={styles.awesomeness_text_container}>
-        <h3>Hillary: Saying Yes</h3>
-        <blockquote>
-          “It's about saying "yes" to yourself, to shedding your fears and
-          leaving them at the door.”
-        </blockquote>
-        <p>
-          How often do you find yourself saying "no,"" or "maybe" instead of
-          saying "Yes"? In today's world, it can be easy to get caught up in
-          social media, the news, and our daily grind. It's important to carve
-          out time to say yes to ourselves and do something that challenges us.
-          The classes at CATCh are all about creating an encouraging environment
-          to students looking to develop the "self," as they express their
-          creativity in a new way.
-        </p>
-      </div>
-      <YoutubeVideoEmbed
-        title="Hillary's Story - CATCh Improv Class"
-        videoId="hDXuUbfYwSU"
-      />
-    </div>
-  </section>
-  <section>
-    <ul class={styles.testimonials}>
-      <li>
-        <Testimonial name="Kristin" image={KristinHeadshot}>
-          “From Day 1, the class taught me not to be fearful and speak up; I
-          felt comfortable being my authentic self.”
-        </Testimonial>
-      </li>
-      <li>
-        <Testimonial name="Kelly" image={KellyHeadshot}>
-          <p>
-            “I'm 4 weeks into my improv class and I am loving it. I have always
-            enjoyed watching improv shows, and would always say 'I could never
-            do that.'
-          </p>
-          <p>
-            Well, here I am, doing it. And it's fun and freeing and motivating.”
-          </p>
-        </Testimonial>
-      </li>
-      <li>
-        <Testimonial name="Jess" image={JessHeadshot}>
-          “Of course I learned a lot about improv and how to work with a scene
-          partner. What I didn't realize was that I would walk away after 6
-          weeks having learned more about myself: how to be open and present to
-          what's in front of you, and to take life, and myself, a little less
-          seriously.”
-        </Testimonial>
-      </li>
     </ul>
   </section>
 </RootLayout>


### PR DESCRIPTION
## What & why
Surfaces student testimonials more prominently on the **Unlocking the Self** class page without pushing the class signups far down the page, and gives the testimonial content a dedicated home.

## Changes
- **Carousel above Upcoming Classes** — student testimonial videos now appear as a compact, horizontally-scrollable carousel of click-to-play thumbnails with short quotes, above the Upcoming Classes section. Built on the existing homepage `card_list` scroll pattern for consistency.
- **Responsive "See all" CTA** — renders inline at the end of the scroll row below `lg`, and as a right-aligned link below the row at `lg`+ (matches the homepage inline-CTA pattern).
- **New `/classes/stories` page** — holds the full testimonial content: Clarissa & Hillary story videos with their full descriptions, plus the Kristin/Kelly/Jess text testimonials (moved here from the class page so nothing is lost). Added to the **Classes** nav.
- **Resilience** — the class-listing fetch on the page now degrades to an empty Upcoming Classes section (with a logged error) instead of 500-ing the whole page if the TicketLeap API fails.

## Notes
- Matches existing conventions (homepage `card_list` / `see_all_link`, sibling class-page layout). The homepage itself is intentionally untouched.
- Adds keyboard a11y to the new scrollers (focusable + aria-label + focus-visible rings).
- Reviewed internally; `astro build` passes.

## Follow-ups (not in this PR)
- The two story video IDs are referenced both in the carousel data and the stories page — fine for two items, tracked for consolidation if the set grows.
- A pre-existing site-wide YouTube-embed alt-text weakness is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)