### PR TITLE
Fix: YouTube embed alt text breaks on titles with apostrophes

### DIFF
--- a/src/components/YoutubeVideoEmbed.astro
+++ b/src/components/YoutubeVideoEmbed.astro
@@ -9,7 +9,7 @@ const { videoId, title } = Astro.props;
 
 <iframe
   src={`https://www.youtube.com/embed/${videoId}`}
-  srcdoc={`<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style><a href=https://www.youtube.com/embed/${videoId}?autoplay=1><img src=https://img.youtube.com/vi/${videoId}/hqdefault.jpg alt='Video ${title}'><span>▶</span></a>`}
+  srcdoc={`<style>*{padding:0;margin:0;overflow:hidden}html,body{height:100%}img,span{position:absolute;width:100%;top:0;bottom:0;margin:auto}span{height:1.5em;text-align:center;font:48px/1.5 sans-serif;color:white;text-shadow:0 0 0.5em black}</style><a href=https://www.youtube.com/embed/${videoId}?autoplay=1><img src=https://img.youtube.com/vi/${videoId}/hqdefault.jpg alt="Video ${title}"><span>▶</span></a>`}
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
   allowfullscreen
   title={title}


### PR DESCRIPTION
## Bug
`YoutubeVideoEmbed` builds a lazy-load `srcdoc` placeholder and puts the title into a **single-quoted** `alt` attribute:

```
alt='Video ${title}'
```

Any title containing an apostrophe — which is every "X's Story" — closes the attribute early. For `"Clarissa's Story — CATCh Improv Classes"` the rendered placeholder becomes:

```
alt='Video Clarissa's Story — CATCh Improv Classes'
```

so inside the iframe document the accessible name truncates to **"Video Clarissa"** and the remainder becomes malformed `<img>` attributes.

## Fix
Switch the `alt` to double quotes (`alt="Video ${title}"`). Apostrophes are safe inside double-quoted attributes, and Astro escapes the outer `srcdoc` attribute, so the placeholder now parses with the full title.

## Verification
Rendered the component with the `Clarissa's Story` title and read the **parsed** `img.alt` inside the srcdoc iframe: it's now the full `"Video Clarissa's Story — CATCh Improv Classes"` (previously `"Video Clarissa"`). `astro build` passes.

## Note
Titles containing a literal double-quote would still need encoding, but no current title does; a fully general fix would mean not building the placeholder as a string attribute. Out of scope for this one-line correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)